### PR TITLE
feat(jury): implement Jury API and refactor RouteInfo into types module

### DIFF
--- a/backend/api/jury/router.py
+++ b/backend/api/jury/router.py
@@ -1,0 +1,52 @@
+from fastapi import HTTPException
+from backend.types import RouteInfo
+from .schemas import GiveMarksRequest, UpdateMarksRequest, MarksResponse
+from .service import give_marks, update_marks
+
+async def give_marks_handler(request: GiveMarksRequest):
+  try:
+    # TODO: Replace with actual jury_id
+    jury_id = 1
+
+    result = await give_marks(
+      jury_id=jury_id,
+      team_id=request.team_id,
+      score=request.score,
+      remarks=request.remarks
+    )
+
+    return result
+  except ValueError as e:
+    raise HTTPException(status_code=400, detail=str(e))
+  
+async def update_marks_handler(team_id: int, request: UpdateMarksRequest):
+  try:
+    # TODO: Replace with actual jury_id
+    jury_id = 1
+
+    result = await update_marks(
+      jury_id=jury_id,
+      team_id=team_id,
+      score=request.score,
+      remarks=request.remarks
+    )
+    return result
+  except ValueError as e:
+    raise HTTPException(status_code=400, detail=str(e))
+  
+JURY_ROUTES: dict[str, RouteInfo] = {
+  "/jury/marks": RouteInfo(
+    name="Give Marks",
+    description="Jury gives marks to a team.",
+    methods_implemented=["POST"],
+    response_model=MarksResponse,
+    handler=give_marks_handler
+  ),
+  "/jury/marks/{team_id}": RouteInfo(
+    name="Update Marks",
+    description="Jury update marks for a team.",
+    methods_implemented=["PUT"],
+    response_model=MarksResponse,
+    handler=update_marks_handler
+  )
+}

--- a/backend/api/jury/schemas.py
+++ b/backend/api/jury/schemas.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel
+
+class GiveMarksRequest(BaseModel):
+  team_id: int
+  score: int
+  remarks: str | None = None
+
+class UpdateMarksRequest(BaseModel):
+  score: int
+  remarks: str | None = None
+
+class MarksResponse(BaseModel):
+  jury_id: int
+  team_id: int
+  score: int
+  remarks: str | None
+

--- a/backend/api/jury/service.py
+++ b/backend/api/jury/service.py
@@ -1,0 +1,23 @@
+JURY_MARKS_DB: dict[tuple[int, int], dict] = {}
+
+async def give_marks(jury_id: int, team_id: int, score: int, remarks: str | None):
+  key = (jury_id, team_id)
+  if key in JURY_MARKS_DB:
+    raise ValueError("Marks already given for this team by jury.")
+  
+  JURY_MARKS_DB[key] = {
+    "jury_id": jury_id,
+    "team_id": team_id,
+    "score": score,
+    "remarks": remarks
+  }
+
+  return JURY_MARKS_DB[key]
+
+async def update_marks(jury_id: int, team_id: int, score: int, remarks: str | None):
+  key = (jury_id, team_id)
+  if key not in JURY_MARKS_DB:
+    raise ValueError("Marks not found! Cannot update.")
+  
+  JURY_MARKS_DB[key].update({"score": score, "remarks": remarks})
+  return JURY_MARKS_DB[key]

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,6 +3,8 @@ from fastapi import FastAPI
 from backend.handlers import health_handler
 from backend.router import RouteInfo, register_routes
 
+from backend.api.jury.router import JURY_ROUTES
+
 server: FastAPI = FastAPI()
 
 
@@ -37,3 +39,4 @@ ROUTES_INFO: dict[str, RouteInfo] = {
 }
 
 register_routes(server, ROUTES_INFO)
+register_routes(server, JURY_ROUTES)

--- a/backend/router.py
+++ b/backend/router.py
@@ -1,20 +1,14 @@
-from collections.abc import Callable
-from types import CoroutineType
-
 from fastapi import FastAPI
-from pydantic import BaseModel
-
-
-class RouteInfo(BaseModel):
-    name: str
-    description: str
-    methods_implemented: list[str]
-    response_model: BaseModel | None
-    handler: Callable[..., CoroutineType[object, object, object] | None]
-
+from backend.types import RouteInfo
+from backend.api.jury.router import JURY_ROUTES
 
 def register_routes(server: FastAPI, routes_info: dict[str, RouteInfo]) -> None:
-    for route_path, route_detail in routes_info.items():
+    all_routes = {
+        **routes_info,
+        **JURY_ROUTES
+    }
+
+    for route_path, route_detail in all_routes.items():
         server.add_api_route(
             route_path,
             route_detail.handler,

--- a/backend/types.py
+++ b/backend/types.py
@@ -1,0 +1,10 @@
+from collections.abc import Callable
+from types import CoroutineType
+from pydantic import BaseModel
+
+class RouteInfo(BaseModel):
+    name: str
+    description: str
+    methods_implemented: list[str]
+    response_model: type[BaseModel] | None
+    handler: Callable[..., CoroutineType | None]


### PR DESCRIPTION
Added:
- Jury API endpoints (POST /jury/marks, PUT /jury/marks/{team_id})
- Schemas: GiveMarksRequest, UpdateMarksRequest, MarksResponse
- Service functions using in-memory mock DB
- Handlers with validation and error handling

Changed:
- Moved RouteInfo from router.py to types.py
- Updated imports and integrated Jury routes into main router

Why:
- RouteInfo refactor improves structure and avoids circular imports